### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/mainnet/quicksilver-2/README.md
+++ b/mainnet/quicksilver-2/README.md
@@ -262,3 +262,7 @@ Check that the service is running:
 ```sh
 sudo systemctl status cosmovisor
 ```
+
+## Network Resources
+
+- [OpenChainBench live latency benchmark](https://openchainbench.com/benchmarks/quicksilver-rpc) — independent p50/p90/p99 latency measurements for free Quicksilver RPC endpoints, updated every 60 s


### PR DESCRIPTION
Adds a **Network Resources** section at the bottom of the quicksilver-2 README with a link to the independent RPC latency benchmark on [OpenChainBench](https://openchainbench.com/benchmarks/quicksilver-rpc).

The benchmark probes the free public Quicksilver RPC endpoints every 60 s and reports p50/p90/p99 latency — useful for validators and integrators choosing which endpoint to connect to.